### PR TITLE
provide better binding between wrappers and solidworks

### DIFF
--- a/Addins.Fluent/QrifyPlus/QrifyPlus.cs
+++ b/Addins.Fluent/QrifyPlus/QrifyPlus.cs
@@ -78,7 +78,7 @@ namespace QrifyPlus
                             {
                                 return new AddinCommand[]
                                 {
-                                    new AddinCommand("QRify+", "QRify+", "QRify+", Properties.Resources.qrifyPlus, nameof(ShowQrifyPlusPmp), enableMethode:nameof(QrifyPlusPmpEnabler)),
+                                    new AddinCommand("QRify+", "QRify+", "QRify+", Properties.Resources.qrifyPlus, nameof(ShowQrifyPlusPmp), enableMethod:nameof(QrifyPlusPmpEnabler)),
                                 };
                             })
                     .SaveCommandGroup()                                         //Save the command group 

--- a/Addins/QRify/qrify.cs
+++ b/Addins/QRify/qrify.cs
@@ -16,7 +16,7 @@ using QRify.Logging;
 
 namespace QRify
 {
-    //It is not mandatory to make this class partial, but in future releases we might use code generators to bypass some of solidworks API restrictions
+    //It is not mandatory to make this class partial, but in future releases we might use code generators to bypass some of SolidWORKS API restrictions
     //AddinIcon could be a resx file or an Embedded Resource one 
     [Addin(title: "QRify",
         AddinIcon = "qrify.png",
@@ -128,10 +128,10 @@ namespace QRify
         {
             this.PmpTabs = new List<PmpTab>() { new QrPropertyManagerPageTab() };
 
-            //at this moment solidworks disables most of its API functions. So if you decided to add a sheet to a drawing for example, it wont work
+            //at this moment SolidWORKS disables most of its API functions. So if you decided to add a sheet to a drawing for example, it wont work
             this.Closing += QrPropertyManagerPage_Closing;
 
-            //this is where you should run any command in solidworks
+            //this is where you should run any command in SolidWORKS
             this.AfterClose += QrPropertyManagerPage_AfterClose;
         }
 
@@ -169,15 +169,15 @@ namespace QRify
             this.CommandTabTextType = ((int)swCommandTabButtonTextDisplay_e.swCommandTabButton_TextBelow);
             this.IconBitmap = Properties.Resources.qrify;
 
-            //Restrictions imposed by solidworks API:
+            //Restrictions imposed by SolidWORKS API:
             //These two methods must be defined in the addin class (addin class inherits from AddinMaker.cs)
-            this.EnableMethode = "EnablePropertyMangagerPage";
+            this.EnableMethod = "EnablePropertyMangagerPage";
             this.CallBackFunction = "ShowQrifyPropertyManagerPage";
 
             this.Name = "QRify";
             this.HintString = "Get QR code";
 
-            //solidworks uses the ToolTip as the command name. maybe its a bug in their API.
+            //SolidWORKS uses the ToolTip as the command name. maybe its a bug in their API.
             //workaround is to use Name as the ToolTip
             this.ToolTip = Name;
         }

--- a/Addins/UI/PropertyManagerPage/PmpControls/Combobox/PmpComboBox.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/Combobox/PmpComboBox.cs
@@ -38,7 +38,7 @@ namespace Hymma.Solidworks.Addins
             AddItems(items);
             Style = _style;
             Height = _height;
-            
+
             //this removed the empty string added to index 0 of Items
             Clear();
             Displaying += PmpComboBox_OnDisplay;
@@ -62,7 +62,7 @@ namespace Hymma.Solidworks.Addins
             //update the backing field
             _items.AddRange(items);
             _items.Sort();
-            //if add in is loaded update the solidworks object
+            //if add in is loaded update the SolidWORKS object
             //otherwise update the property after display
             if (SolidworksObject != null)
             {
@@ -98,6 +98,7 @@ namespace Hymma.Solidworks.Addins
         {
             return _items.Contains(item);
         }
+
         /// <summary>
         /// Clears all items from the attached drop-down list for this combo box.  
         /// </summary>
@@ -119,13 +120,14 @@ namespace Hymma.Solidworks.Addins
             //update the backing field
             _items.RemoveAt(index);
 
-            //if add in is loaded update the solidworks object
+            //if add in is loaded update the SolidWORKS object
             //otherwise update the property after display
             if (SolidworksObject != null)
                 SolidworksObject.DeleteItem(index);
             else
                 Registering += () => { SolidworksObject.DeleteItem(index); };
         }
+
         /// <summary>
         /// Inserts an item in the attached drop-down list of this combo box. 
         /// </summary>
@@ -137,7 +139,7 @@ namespace Hymma.Solidworks.Addins
                 return;
             _items.Add(item);
             _items.Sort();
-            //if add in is loaded update the solidworks object
+            //if add in is loaded update the SolidWORKS object
             //otherwise update the property after display
             if (SolidworksObject != null)
             {
@@ -155,12 +157,11 @@ namespace Hymma.Solidworks.Addins
             }
         }
 
-
         #endregion
 
         #region public properties
         /// <summary>
-        /// items in the combo-box the index of these items is not the same as solidworks UI and is not reliable
+        /// items in the combo-box the index of these items is not the same as SolidWORKS UI and is not reliable
         /// </summary>
         public ReadOnlyCollection<string> Items => _items.AsReadOnly();
 
@@ -175,7 +176,7 @@ namespace Hymma.Solidworks.Addins
                 //assign value to the backing field
                 _height = value;
 
-                //if add in is loaded update the solidworks object
+                //if add in is loaded update the SolidWORKS object
                 //otherwise update the property after display
                 if (SolidworksObject != null)
                     SolidworksObject.Height = value;
@@ -203,7 +204,7 @@ namespace Hymma.Solidworks.Addins
                 //assign value to the  field
                 _style = value;
 
-                //if add in is loaded update the solidworks object
+                //if add in is loaded update the SolidWORKS object
                 //otherwise update the property after display
                 if (SolidworksObject != null)
                     SolidworksObject.Style = (int)value;
@@ -222,7 +223,7 @@ namespace Hymma.Solidworks.Addins
             get => SolidworksObject.CurrentSelection;
             set
             {
-                //if add in is loaded update the solidworks object
+                //if add in is loaded update the SolidWORKS object
                 //otherwise update the property after display
                 if (SolidworksObject != null)
                     SolidworksObject.CurrentSelection = value;
@@ -269,11 +270,11 @@ namespace Hymma.Solidworks.Addins
         /// <summary>
         /// Called when a user changes the selected item in a combo box on this PropertyManager page. 
         /// </summary>
-        /// <remarks>solidworks will pass int the id of the selected item</remarks>
+        /// <remarks>SolidWORKS will pass int the id of the selected item</remarks>
         public event EventHandler<int> SelectionChanged;
 
         /// <summary>
-        /// Called when a user changes the text string in the text box of a combo box on this PropertyManager page. solidworks will pass in the text string
+        /// Called when a user changes the text string in the text box of a combo box on this PropertyManager page. SolidWORKS will pass in the text string
         /// </summary>
         /// <remarks>
         /// <para>

--- a/Addins/UI/PropertyManagerPage/PmpControls/Group/PmpGroup.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/Group/PmpGroup.cs
@@ -43,6 +43,13 @@ namespace Hymma.Solidworks.Addins
             IsExpanded = expanded;
             Visible = visible;
             Controls = new List<IPmpControl>();
+            Expanded += PmpGroup_Expanded;
+        }
+
+        private void PmpGroup_Expanded(object sender, bool e)
+        {
+            if (_isExpanded != e)
+                _isExpanded = e;
         }
 
         /// <summary>
@@ -240,7 +247,7 @@ namespace Hymma.Solidworks.Addins
         /// </summary>
         public event EventHandler<bool> Expanded;
 
-        
+
         #endregion
 
         #region call backs

--- a/Addins/UI/PropertyManagerPage/PmpControls/Group/PmpGroupCheckable.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/Group/PmpGroupCheckable.cs
@@ -26,6 +26,13 @@ namespace Hymma.Solidworks.Addins
             IsChecked = isChecked;
             _options = swAddGroupBoxOptions_e.swGroupBoxOptions_Checkbox;
             Displaying += PmpGroupCheckable_OnDisplay;
+            Checked += PmpGroupCheckable_Checked;
+        }
+
+        private void PmpGroupCheckable_Checked(object sender, bool e)
+        {
+            if (_isChecked!=e)
+                _isChecked = e;
         }
 
         private void PmpGroupCheckable_OnDisplay(object sender, EventArgs e)

--- a/Addins/UI/PropertyManagerPage/PmpControls/NumberBox/Enums/NumberBoxUnit.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/NumberBox/Enums/NumberBoxUnit.cs
@@ -4,7 +4,7 @@
 namespace Hymma.Solidworks.Addins
 {
     /// <summary>
-    /// units for numberbox
+    /// units for <see cref="PmpNumberBox"/>
     /// </summary>
     public enum NumberBoxUnit
     {
@@ -53,12 +53,12 @@ namespace Hymma.Solidworks.Addins
         Time = 9,
 
         /// <summary>
-        /// unitless doulbe
+        /// unitless double
         /// </summary>
         UnitlessDouble = 2,
 
         /// <summary>
-        /// unitles integer
+        /// unitless integer
         /// </summary>
         UnitlessInteger = 1
     }

--- a/Addins/UI/PropertyManagerPage/PmpControls/NumberBox/PmpNumberBox.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/NumberBox/PmpNumberBox.cs
@@ -64,7 +64,7 @@ namespace Hymma.Solidworks.Addins
         /// You cannot change Units once the page is displayed.The Units parameter is ignored if specified while the page is displayed. <br/>
         ///If the range is changed to an invalid value by this method, then you must immediately call <see cref="Value"/> and set a valid value to prevent displaying the dialog that requests the user to enter a valid value. 
         ///<para>
-        ///SolidWORKS internal units are <strong>meteric</strong> it will treat this methods parameters as such. for example increment will be Meter for lenghts
+        ///SolidWORKS internal units are <strong>metric</strong> it will treat this methods parameters as such. for example increment will be Meter for lengths. 
         ///</para>
         ///</remarks>
         public void SetRange(NumberBoxUnit Units, double Minimum, double Maximum, bool Inclusive, double Increment, double fastIncrement, double slowIncrement)

--- a/Addins/UI/PropertyManagerPage/PmpControls/NumberBox/PmpNumberBox.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/NumberBox/PmpNumberBox.cs
@@ -24,7 +24,7 @@ namespace Hymma.Solidworks.Addins
         /// creates a number box in a property manager page
         /// </summary>
         /// <param name="style">style for this numberBox as defined by <see cref="NumberBoxStyles"/></param>
-        public PmpNumberBox(NumberBoxStyles style=NumberBoxStyles.Default) : base(swPropertyManagerPageControlType_e.swControlType_Numberbox)
+        public PmpNumberBox(NumberBoxStyles style = NumberBoxStyles.Default) : base(swPropertyManagerPageControlType_e.swControlType_Numberbox)
         {
             Style = style;
         }
@@ -117,19 +117,20 @@ namespace Hymma.Solidworks.Addins
         /// <summary>
         /// Gets and sets the value that appears in the number box. 
         /// </summary>
-        public double Value
+        ///<remarks>will be null if called before <see cref="PmpGroup.AddControl(IPmpControl)"/></remarks>
+        public double? Value
         {
-            get => _value;
+            get => SolidworksObject?.Value;
             set
             {
-                _value = value;
+                //_value = value;
                 if (SolidworksObject != null)
                 {
-                    SolidworksObject.Value = value;
+                    SolidworksObject.Value = value ?? 0;
                 }
                 else
                 {
-                    Registering += () => { SolidworksObject.Value = value; };
+                    Registering += () => { SolidworksObject.Value = value ?? 0; };
                 }
             }
         }
@@ -206,7 +207,7 @@ namespace Hymma.Solidworks.Addins
 
         internal void TrackingCompletedCallback(double val) => TrackingCompleted?.Invoke(this, val);
         internal void SelectionChangedCallback(int item)
-         =>SelectionChanged?.Invoke(this, SolidworksObject.ItemText[(short)item]);
+         => SelectionChanged?.Invoke(this, SolidworksObject.ItemText[(short)item]);
         #endregion
 
         #region events
@@ -230,7 +231,7 @@ namespace Hymma.Solidworks.Addins
         /// <summary>
         /// fired when Style has <see cref="NumberBoxStyles.AvoidSelectionText"/> | <see cref="NumberBoxStyles.ComboEditBox"/> and user selects an item from the combo box
         /// </summary>
-         public event EventHandler<string> SelectionChanged;
+        public event EventHandler<string> SelectionChanged;
 
         /// <summary>
         /// fired a moment before this number box is displayed in a property manager page

--- a/Addins/UI/PropertyManagerPage/PmpControls/NumberBox/PmpNumberBox.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/NumberBox/PmpNumberBox.cs
@@ -64,7 +64,7 @@ namespace Hymma.Solidworks.Addins
         /// You cannot change Units once the page is displayed.The Units parameter is ignored if specified while the page is displayed. <br/>
         ///If the range is changed to an invalid value by this method, then you must immediately call <see cref="Value"/> and set a valid value to prevent displaying the dialog that requests the user to enter a valid value. 
         ///<para>
-        ///solidworks internal units are <strong>meteric</strong> it will treat this methods parameters as such. for example increment will be Meter for lenghts
+        ///SolidWORKS internal units are <strong>meteric</strong> it will treat this methods parameters as such. for example increment will be Meter for lenghts
         ///</para>
         ///</remarks>
         public void SetRange(NumberBoxUnit Units, double Minimum, double Maximum, bool Inclusive, double Increment, double fastIncrement, double slowIncrement)
@@ -212,14 +212,14 @@ namespace Hymma.Solidworks.Addins
         #region events
 
         /// <summary>
-        /// called when user changes the value in an number box by typing in a new value, solidworks will pass in the text that was entered
+        /// called when user changes the value in an number box by typing in a new value, SolidWORKS will pass in the text that was entered
         /// </summary>
         public event EventHandler<string> TextChanged;
 
         /// <summary>
         /// fired when user changes the value via typing or clicking the up-arrow or down-arrow buttons to increment or decrement the value
         /// </summary>
-        /// <remarks>solidworks will pass in the double value upon change</remarks>
+        /// <remarks>SolidWORKS will pass in the double value upon change</remarks>
         public event EventHandler<double> Changing;
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Hymma.Solidworks.Addins
         /// <summary>
         /// fired when Style has <see cref="NumberBoxStyles.AvoidSelectionText"/> | <see cref="NumberBoxStyles.ComboEditBox"/> and user selects an item from the combo box
         /// </summary>
-        public event EventHandler<string> SelectionChanged;
+         public event EventHandler<string> SelectionChanged;
 
         /// <summary>
         /// fired a moment before this number box is displayed in a property manager page

--- a/Addins/UI/PropertyManagerPage/PmpControls/RadioButton/PmpRadioButton.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/RadioButton/PmpRadioButton.cs
@@ -22,8 +22,17 @@ namespace Hymma.Solidworks.Addins
         public PmpRadioButton(string caption, bool isChecked = false) : base(swPropertyManagerPageControlType_e.swControlType_Option, caption)
         {
             IsChecked = isChecked;
+
+            //bind this to SolidWORKS
+            Checked += PmpRadioButton_Checked;
         }
-        
+
+        private void PmpRadioButton_Checked(object sender, bool e)
+        {
+            if (_isChecked != e)
+                _isChecked = e;
+        }
+
         #region properties
 
         /// <summary>
@@ -70,14 +79,14 @@ namespace Hymma.Solidworks.Addins
         #endregion
 
         #region call backs
-        internal void CheckedCallback() =>Checked?.Invoke(this, EventArgs.Empty);
+        internal void CheckedCallback() => Checked?.Invoke(this, true);
         #endregion
 
         #region events
         /// <summary>
         /// SOLIDWORKS will invoke this delegate once the user checks this radio button
         /// </summary>
-        public EventHandler Checked;
+        public event EventHandler<bool> Checked;
         private bool _maintain;
         #endregion
     }

--- a/Addins/UI/PropertyManagerPage/PmpControls/RadioButton/PmpRadioButton.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/RadioButton/PmpRadioButton.cs
@@ -8,14 +8,14 @@ using System;
 namespace Hymma.Solidworks.Addins
 {
     /// <summary>
-    /// a solidworks radio button in property managers
+    /// a SolidWORKS radio button in property managers
     /// </summary>
     public class PmpRadioButton : PmpControl<IPropertyManagerPageOption>
     {
         private bool _isChecked;
 
         /// <summary>
-        /// make a new radio button for solidworks property manager pages
+        /// make a new radio button for SolidWORKS property manager pages
         /// </summary>
         /// <param name="caption">caption for this radio button</param>
         /// <param name="isChecked">whether it is going to be the checked or not</param>
@@ -44,12 +44,12 @@ namespace Hymma.Solidworks.Addins
         }
 
         /// <summary>
-        /// provide a consitant experience between sessions of calling a property manager 
+        /// provide a constant experience between sessions of calling a property manager 
         ///we update the status of the control to that of previous call
         /// </summary>
-        /// <remarks>solidworks requires us to regiter the control once the addin is loaded.
-        ///then everytime the property manage rpage is displayed the status of controls would reflect the registered state
-        ///but to provide a consitant experience between sessions of calling a property manager 
+        /// <remarks>SolidWORKS requires us to register the control once the addin is loaded.
+        ///then every time the property manager page is displayed the status of controls would reflect the registered state
+        ///but to provide a constant experience between sessions of calling a property manager 
         ///we use this property to update the status of the control to that of previous call</remarks>
         public bool MaintainState
         {

--- a/Addins/UI/PropertyManagerPage/PmpControls/SelectionBox/PmpSelectionBox.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/SelectionBox/PmpSelectionBox.cs
@@ -10,7 +10,7 @@ using System.Linq;
 namespace Hymma.Solidworks.Addins
 {
     /// <summary>
-    /// a solidworks selection box 
+    /// a SolidWORKS selection box 
     /// </summary>
     public class PmpSelectionBox : PmpControl<IPropertyManagerPageSelectionbox>
     {
@@ -43,8 +43,8 @@ namespace Hymma.Solidworks.Addins
         /// <param name="allowMultipleSelectOfSameEntity">True if the same entity can be selected multiple times in this selection box, false if not</param>
         /// <param name="style">style of this selection box as defined by bitwise <see cref="SelectionBoxStyles"/></param>
         /// <param name="singleItemOnly">Gets or sets whether this selection box is for single or multiple items. </param>
-        /// <param name="height">height of selectionbox in the pmp</param>
-        /// <param name="tip">tip for the selectionbox</param>
+        /// <param name="height">height of selection-box in the pmp</param>
+        /// <param name="tip">tip for the selection-box</param>
         public PmpSelectionBox(IEnumerable<swSelectType_e> filters, SelectionBoxStyles style = SelectionBoxStyles.Default, bool allowMultipleSelectOfSameEntity = true, bool singleItemOnly = false, short height = 50, string tip = "")
             : base(swPropertyManagerPageControlType_e.swControlType_Selectionbox, "", tip)
         {
@@ -69,7 +69,7 @@ namespace Hymma.Solidworks.Addins
             SolidworksObject.AllowMultipleSelectOfSameEntity = _allowMultipleSelectOfSameEntity;
             SolidworksObject.SingleEntityOnly = _singleItemOnly;
 
-            // this is not available in solidworks 2018 and earlier
+            // this is not available in SolidWORKS 2018 and earlier
             //SolidworksObject.EnableSelectIdenticalComponents = _enableSelectIdenticalComponents;
             SolidworksObject.Height = _height;
             SolidworksObject.SetSelectionFilters(_filters.Cast<int>().ToArray());
@@ -107,17 +107,17 @@ namespace Hymma.Solidworks.Addins
 
         #region public properties
         /// <summary>
-        /// Once user RMB on the selection box these items will be listed in the menue that appears
+        /// Once user RMB on the selection box these items will be listed in the  menu that appears
         /// </summary>
         public List<PopUpMenueItem> PopUpMenueItems { get; set; }
 
         /// <summary>
-        /// PropertyManager page's cursor after a user makes a selection in the SOLIDWORKS graphics area. 
+        /// PropertyManager page's cursor after a user makes a selection in the SolidWORKS graphics area. 
         /// </summary>
         /// <remarks>allows an interactive user to either: <br/>
         ///move to the next selection box on the PropertyManager page or <br/>
         ///okay and close a PropertyManager page<br/>
-        ///after making a selection in the SOLIDWORKS graphics area. </remarks>
+        ///after making a selection in the SolidWORKS graphics area. </remarks>
         public PmpCursorStyles CursorStyle { get; set; } = PmpCursorStyles.None;
 
         /// <summary>
@@ -144,9 +144,9 @@ namespace Hymma.Solidworks.Addins
 
 
         /// <summary>
-        /// create a clalout for this selectionbox
+        /// create a callout for this selection-box
         /// </summary>
-        /// <remarks>you should use this property in the context of a part or assembly or drawing environment i.e you cannot use it when solidworks starts</remarks>
+        /// <remarks>you should use this property in the context of a part or assembly or drawing environment i.e you cannot use it when SolidWORKS starts</remarks>
         public CalloutModel Callout
         {
             get => _callout;
@@ -193,7 +193,7 @@ namespace Hymma.Solidworks.Addins
         public bool IsFocused => SolidworksObject != null && SolidworksObject.GetSelectionFocus();
         /*
        <<<<<<<<<<
-        this is not available in SOLIDWORKS API 2018
+        this is not available in SolidWORKS API 2018
        >>>>>>>>>> 
 
       /// <summary>
@@ -244,7 +244,7 @@ namespace Hymma.Solidworks.Addins
 
             set
             {
-                // Mark values(whether set by the SolidWorks application or by your application) must be powers of two(for example, 1, 2, 4, 8)
+                // Mark values(whether set by the SolidWORKS application or by your application) must be powers of two(for example, 1, 2, 4, 8)
                 var isPowerOfTwo = (value != 0) && ((value & (value - 1)) == 0);
 
                 if (isPowerOfTwo)
@@ -274,7 +274,7 @@ namespace Hymma.Solidworks.Addins
         /// gets a dicitonary of items and their type in a selection box whether they are selected or not
         /// folow instructions in the link below to get the actual object of the selected item 
         /// </summary>
-        ///<remarks> <a href="http://help.solidworks.com/2019/english/api/swconst/SOLIDWORKS.Interop.swconst~SOLIDWORKS.Interop.swconst.swSelectType_e.html">solidworks website</a>
+        ///<remarks> <a href="http://help.solidworks.com/2019/english/api/swconst/SOLIDWORKS.Interop.swconst~SOLIDWORKS.Interop.swconst.swSelectType_e.html">SolidWORKS website</a>
         ///<list type="bullet">
         ///<item>IF . . . . . . . . . . . . . . .<description> . . .THEN THIS METHOD RETURNS</description></item>
         ///<item>Reference surfaces are selected. . . . . .<description>Reference surface faces instead of the entire reference surface feature.</description></item>
@@ -300,7 +300,7 @@ namespace Hymma.Solidworks.Addins
         /// folow instructions in the link below to get the actual object of the selected item 
         /// </summary>
         /// <param name="index">0-based index of the item in the selection manager</param>
-        ///<remarks> <a href="http://help.solidworks.com/2019/english/api/swconst/SOLIDWORKS.Interop.swconst~SOLIDWORKS.Interop.swconst.swSelectType_e.html">solidworks website</a>
+        ///<remarks> <a href="http://help.solidworks.com/2019/english/api/swconst/SOLIDWORKS.Interop.swconst~SOLIDWORKS.Interop.swconst.swSelectType_e.html">SolidWORKS website</a>
         ///<list type="bullet">
         ///<item>IF . . . . . . . . . . . . . . .<description> . . .THEN THIS METHOD RETURNS</description></item>
         ///<item>Reference surfaces are selected. . . . . .<description>Reference surface faces instead of the entire reference surface feature.</description></item>
@@ -336,19 +336,19 @@ namespace Hymma.Solidworks.Addins
 
         #region events
         /// <summary>
-        /// SOLIDWORKS will invoke this once focus is changed from this selection box
+        /// SolidWORKS will invoke this once focus is changed from this selection box
         /// </summary>
         public event PmpSelectionBoxEventHandler FocusChanged;
 
         /// <summary>
-        /// SOLIDWORKS will invoke this once a call-out is created for this selection box<br/>
+        /// SolidWORKS will invoke this once a call-out is created for this selection box<br/>
         /// allows you to collect information such as the selection type from the last selection. Next, use the <see cref="Callout"/> property to get the Callout object. <br/>
         /// Then, use that object's various properties to control the callout text and display characteristics based on that selection information.
         /// </summary>
         public event PmpSelectionBoxEventHandler CallOutCreated;
 
         /// <summary>
-        /// SOLIDWORKS will invoke this once a callout is destroyed
+        /// SolidWORKS will invoke this once a callout is destroyed
         /// </summary>
         public event PmpSelectionBoxEventHandler CallOutDestroyed;
 
@@ -362,7 +362,7 @@ namespace Hymma.Solidworks.Addins
         /// you should pass a delegate that accepts (object WhatIsSelected, int swSelectType_e, string tag)
         /// </summary>
         /// <remarks> 
-        /// <para>This method is called by SOLIDWORKS when an add-in 
+        /// <para>This method is called by SolidWORKS when an add-in 
         /// has a PropertyManager page displayed and a selection is made that passes the selection 
         /// filter criteria set up for a selection list box. The add-in can then:<br/> 
         /// </para>
@@ -372,13 +372,13 @@ namespace Hymma.Solidworks.Addins
         /// <item>Use methods or properties of that interface to determine if the selection should be allowed or not.If the selection is:
         /// <list type="bullet">
         /// <item>accepted, return true, and processing continues normally.</item>
-        /// <item>rejected, return false, and SOLIDWORKS does not accept the selection, just as if the selection did not pass the selection filter criteria of the selection list box.</item>
+        /// <item>rejected, return false, and SolidWORKS does not accept the selection, just as if the selection did not pass the selection filter criteria of the selection list box.</item>
         /// </list>
         /// </item>
         /// </list>
         /// <para>
-        ///The add-in should not release the Dispatch pointer. SOLIDWORKS will release the Dispatch pointer upon return from this method.
-        ///The method is called during the process of SOLIDWORKS selection.It is neither a pre-notification nor post-notification. <br/>
+        ///The add-in should not release the Dispatch pointer. SolidWORKS will release the Dispatch pointer upon return from this method.
+        ///The method is called during the process of SolidWORKS selection.It is neither a pre-notification nor post-notification. <br/>
         ///The add-in should not be taking any action that might affect the model or the selection list.The add-in should only be querying information and then returning true/VARIANT_TRUE or false/VARIANT_FALSE.
         /// </para>
         /// </remarks>

--- a/Addins/UI/PropertyManagerPage/PmpControls/SelectionBox/PmpSelectionBox.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/SelectionBox/PmpSelectionBox.cs
@@ -271,8 +271,8 @@ namespace Hymma.Solidworks.Addins
         }
 
         /// <summary>
-        /// gets a dicitonary of items and their type in a selection box whether they are selected or not
-        /// folow instructions in the link below to get the actual object of the selected item 
+        /// gets a dictionary of items and their type in a selection box whether they are selected or not
+        /// follow instructions in the link below to get the actual object of the selected item 
         /// </summary>
         ///<remarks> <a href="http://help.solidworks.com/2019/english/api/swconst/SOLIDWORKS.Interop.swconst~SOLIDWORKS.Interop.swconst.swSelectType_e.html">SolidWORKS website</a>
         ///<list type="bullet">
@@ -284,7 +284,7 @@ namespace Hymma.Solidworks.Addins
         ///<item>Called in a drawing document . . . . . .<description>Selected <see cref="IDrawingComponent"/> object. </description></item>
         ///<item>Called in a part or assembly document . . . . . .<description> <see cref="IComponent2"/> object. </description></item>
         /// </list></remarks> 
-        /// <returns> a dicitonary of items and their type as defined in <see cref="swSelectType_e"/> Nothing or null might be returned if the type is not supported or if nothing is selected</returns>
+        /// <returns> a dictionary of items and their type as defined in <see cref="swSelectType_e"/> Nothing or null might be returned if the type is not supported or if nothing is selected</returns>
         public IEnumerable<KeyValuePair<object, swSelectType_e>> GetItems()
         {
             var itemsTypes = new List<KeyValuePair<object, swSelectType_e>>();
@@ -297,7 +297,7 @@ namespace Hymma.Solidworks.Addins
 
         /// <summary>
         /// get the specified item in the selection box <br/>
-        /// folow instructions in the link below to get the actual object of the selected item 
+        /// follow instructions in the link below to get the actual object of the selected item 
         /// </summary>
         /// <param name="index">0-based index of the item in the selection manager</param>
         ///<remarks> <a href="http://help.solidworks.com/2019/english/api/swconst/SOLIDWORKS.Interop.swconst~SOLIDWORKS.Interop.swconst.swSelectType_e.html">SolidWORKS website</a>

--- a/Addins/UI/PropertyManagerPage/PmpControls/Slider/PmpSlider.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/Slider/PmpSlider.cs
@@ -39,6 +39,15 @@ namespace Hymma.Solidworks.Addins
             _position = 5;
             _rangeMin = 0;
             _rangeMax = 10;
+
+            //bind SolidWORKS object with this
+            TrackingCompleted += PmpSlider_TrackingCompleted;
+        }
+
+        private void PmpSlider_TrackingCompleted(object sender, double e)
+        {
+            if (_position!=e)
+                _position = e;
         }
         #endregion
 

--- a/Addins/UI/PropertyManagerPage/PmpControls/TextBox/PmpTextBox.cs
+++ b/Addins/UI/PropertyManagerPage/PmpControls/TextBox/PmpTextBox.cs
@@ -23,7 +23,7 @@ namespace Hymma.Solidworks.Addins
         /// <summary>
         /// make a text box for a property manager page in soldiworks
         /// </summary>
-        /// <param name="initialValue">initial value for this text box once generated in a porperty manager page</param>
+        /// <param name="initialValue">initial value for this text box once generated in a property manager page</param>
         /// <param name="tip">a tip for this text box</param>
         public PmpTextBox(string initialValue = "",string tip="") : base(swPropertyManagerPageControlType_e.swControlType_Textbox,tip:tip)
         {

--- a/Addins/UI/ToolbarTabs/CommandGroup/AddinCommand.cs
+++ b/Addins/UI/ToolbarTabs/CommandGroup/AddinCommand.cs
@@ -31,7 +31,7 @@ namespace Hymma.Solidworks.Addins
         /// <param name="userId">a user id for this command</param>
         /// <param name="menuOption">whether this command should be in menu or toolbox or both as defined in <see cref="swCommandItemType_e"/><br/></param>
         /// <param name="tabTextStyle">text display of this command when used in a <see cref="AddinCommandTab"/> as defined by <see cref="swCommandTabButtonTextDisplay_e"/></param>
-        /// <param name="enableMethode">name of optional function that controls the state of the item; if specified, then SOLIDWORKS calls this function before displaying the item 
+        /// <param name="enableMethod">name of optional function that controls the state of the item; if specified, then SOLIDWORKS calls this function before displaying the item 
         /// <strong>THIS FUNCTION MUST BE DEFINED IN THE ADDIN CLASS. ADDIN CLASS IS THE ONE THAT INHERITS FROM <see cref="AddinMaker"/></strong>
         /// <list type="table">
         /// <listheader>
@@ -44,7 +44,7 @@ namespace Hymma.Solidworks.Addins
         /// <item>3<term></term><description>SOLIDWORKS Selects and enables the item</description></item>
         /// <item>4<term></term><description>Not supported</description></item>
         /// </list></param>
-        public AddinCommand(string name, string hint, string tooltipTitle, Bitmap icon, string nameofCallBackFunc, short userId = 0, int menuOption = 3, int tabTextStyle = 2, string enableMethode = "")
+        public AddinCommand(string name, string hint, string tooltipTitle, Bitmap icon, string nameofCallBackFunc, short userId = 0, int menuOption = 3, int tabTextStyle = 2, string enableMethod = "")
         {
             #region assign values to properties
             Name = name;
@@ -55,7 +55,7 @@ namespace Hymma.Solidworks.Addins
             UserId = userId;
             MenueOptions = menuOption;
             CommandTabTextType = tabTextStyle;
-            EnableMethode = enableMethode;
+            EnableMethode = enableMethod;
             #endregion
         }
         #endregion

--- a/Addins/UI/ToolbarTabs/CommandGroup/AddinCommand.cs
+++ b/Addins/UI/ToolbarTabs/CommandGroup/AddinCommand.cs
@@ -53,9 +53,9 @@ namespace Hymma.Solidworks.Addins
             IconBitmap = icon;
             CallBackFunction = nameofCallBackFunc;
             UserId = userId;
-            MenueOptions = menuOption;
+            MenuOptions = menuOption;
             CommandTabTextType = tabTextStyle;
-            EnableMethode = enableMethod;
+            EnableMethod = enableMethod;
             #endregion
         }
         #endregion
@@ -70,7 +70,7 @@ namespace Hymma.Solidworks.Addins
         /// </summary>
         public int Index { get;internal set; }
         /// <summary>
-        /// name as appears in solidworks
+        /// name as appears in SolidWORKS
         /// </summary>
         public string Name { get; set; }
 
@@ -110,7 +110,7 @@ namespace Hymma.Solidworks.Addins
         /// </list>
         /// </summary>
         /// <remarks><strong>THIS FUNCTION MUST BE DEFINED IN THE ADDIN CLASS. ADDIN CLASS IS THE ONE THAT INHERITS FROM <see cref="AddinMaker"/></strong></remarks>
-        public string EnableMethode { get; set; } = "";
+        public string EnableMethod { get; set; } = "";
 
         /// <summary>
         /// User-defined command ID or 0 if not used
@@ -118,7 +118,7 @@ namespace Hymma.Solidworks.Addins
         public int UserId { get; set; } = 0;
 
         /// <summary>
-        /// Id that solidworks assigns to this command once created. it then gets used by command boxes
+        /// Id that SolidWORKS assigns to this command once created. it then gets used by command boxes
         /// </summary>
         public int SolidworksId { get;internal set; }
 
@@ -126,7 +126,7 @@ namespace Hymma.Solidworks.Addins
         /// whether this command should be in menu or toolbox or both as defined in <see cref="swCommandItemType_e"/><br/>
         /// default is 3
         /// </summary>
-        public int MenueOptions { get; set; } = 3;
+        public int MenuOptions { get; set; } = 3;
 
         /// <summary>
         /// text display of this command when used in a <see cref="AddinCommandTab"/> as defined by <see cref="swCommandTabButtonTextDisplay_e"/><br/>

--- a/Addins/UI/ToolbarTabs/CommandGroup/AddinCommandGroup.cs
+++ b/Addins/UI/ToolbarTabs/CommandGroup/AddinCommandGroup.cs
@@ -77,9 +77,9 @@ namespace Hymma.Solidworks.Addins
                     , command.ToolTip
                     , imageIndex
                     , command.CallBackFunction
-                    , command.EnableMethode
+                    , command.EnableMethod
                     , command.UserId
-                    , command.MenueOptions);
+                    , command.MenuOptions);
 
                 //assign the index we got to command
                 command.Index = index;


### PR DESCRIPTION
Wrapper classes in the Property Management Pages had to subscribe to the events and update their own states. For example, the `Value` of the `PmpTextBox.cs` would not reflect the current state of the UI unless we had subscribed to the `PmpTextBox.TypedInto` event. 
Now, the caller of the `PmpTextBox` can simply read the most up-to-date UI value from the `Value` property. 